### PR TITLE
HOTFIX for terraform route53.tf errors in development branch.

### DIFF
--- a/terraform/environments/new/route53.tf
+++ b/terraform/environments/new/route53.tf
@@ -20,6 +20,7 @@ output "omega_public_dns_servers" {
   value       = aws_route53_zone.omega_public_dns.name_servers
 }
 
+/*
 resource "aws_route53_record" "dns_a_wildcard_in_catalogue_nationalarchives_gov_uk" {
   zone_id = aws_route53_zone.omega_public_dns.zone_id
   name    = "*.${local.public_dns_domain}"
@@ -35,6 +36,7 @@ resource "aws_route53_record" "dns_a_www_in_catalogue_nationalarchives_gov_uk" {
   ttl     = "300"
   records = data.aws_network_interface.web_proxy_1_private_interface.private_ips
 }
+*/
 
 resource "aws_route53_zone" "omega_private_omg_dns" {
   name = local.private_omg_dns_domain
@@ -53,6 +55,7 @@ output "omega_private_omg_dns_servers" {
   value       = aws_route53_zone.omega_private_omg_dns.name_servers
 }
 
+/*
 resource "aws_route53_record" "dns_a_web_proxy_1_in_omg_catalogue_nationalarchives_gov_uk" {
   zone_id = aws_route53_zone.omega_private_omg_dns.zone_id
   name    = "web-proxy-1.${local.private_omg_dns_domain}"
@@ -108,3 +111,4 @@ resource "aws_route53_record" "dns_a_mssql1_in_omg_catalogue_nationalarchives_go
   ttl     = "300"
   records = data.aws_network_interface.dev_mssql_server_1_database_interface.private_ips
 }
+*/


### PR DESCRIPTION
Commented out the route53 record resources that use the data sources listed as missing in the error output.

`❯ terraform plan
Acquiring state lock. This may take a few moments...
Releasing state lock. This may take a few moments...
╷
│ Error: Reference to undeclared resource
│
│   on route53.tf line 28, in resource "aws_route53_record" "dns_a_wildcard_in_catalogue_nationalarchives_gov_uk":
│   28:   records = data.aws_network_interface.web_proxy_1_private_interface.private_ips
│
│ A data resource "aws_network_interface" "web_proxy_1_private_interface" has not been
│ declared in the root module.
╵
╷
│ Error: Reference to undeclared resource
│
│   on route53.tf line 36, in resource "aws_route53_record" "dns_a_www_in_catalogue_nationalarchives_gov_uk":
│   36:   records = data.aws_network_interface.web_proxy_1_private_interface.private_ips
│
│ A data resource "aws_network_interface" "web_proxy_1_private_interface" has not been
│ declared in the root module.
╵
╷
│ Error: Reference to undeclared resource
│
│   on route53.tf line 61, in resource "aws_route53_record" "dns_a_web_proxy_1_in_omg_catalogue_nationalarchives_gov_uk":
│   61:   records = data.aws_network_interface.web_proxy_1_private_interface.private_ips
│
│ A data resource "aws_network_interface" "web_proxy_1_private_interface" has not been
│ declared in the root module.
╵
╷
│ Error: Reference to undeclared resource
│
│   on route53.tf line 69, in resource "aws_route53_record" "dns_a_web_app_1_in_omg_catalogue_nationalarchives_gov_uk":
│   69:   records = data.aws_network_interface.web_app_1_private_interface.private_ips
│
│ A data resource "aws_network_interface" "web_app_1_private_interface" has not been
│ declared in the root module.
╵
╷
│ Error: Reference to undeclared resource
│
│   on route53.tf line 77, in resource "aws_route53_record" "dns_a_services_api_1_in_omg_catalogue_nationalarchives_gov_uk":
│   77:   records = data.aws_network_interface.services_api_1_private_interface.private_ips
│
│ A data resource "aws_network_interface" "services_api_1_private_interface" has not been
│ declared in the root module.
╵
╷
│ Error: Reference to undeclared resource
│
│   on route53.tf line 85, in resource "aws_route53_record" "dns_a_puppet_server_1_in_omg_catalogue_nationalarchives_gov_uk":
│   85:   records = data.aws_network_interface.puppet_server_1_private_interface.private_ips
│
│ A data resource "aws_network_interface" "puppet_server_1_private_interface" has not been
│ declared in the root module.
╵
╷
│ Error: Reference to undeclared resource
│
│   on route53.tf line 93, in resource "aws_route53_record" "dns_a_dev1_in_omg_catalogue_nationalarchives_gov_uk":
│   93:   records = data.aws_network_interface.dev_workstation_1_private_interface.private_ips
│
│ A data resource "aws_network_interface" "dev_workstation_1_private_interface" has not
│ been declared in the root module.
╵
╷
│ Error: Reference to undeclared resource
│
│   on route53.tf line 101, in resource "aws_route53_record" "dns_a_dev2_in_omg_catalogue_nationalarchives_gov_uk":
│  101:   records = data.aws_network_interface.dev_workstation_2_private_interface.private_ips
│
│ A data resource "aws_network_interface" "dev_workstation_2_private_interface" has not
│ been declared in the root module.
╵
╷
│ Error: Reference to undeclared resource
│
│   on route53.tf line 109, in resource "aws_route53_record" "dns_a_mssql1_in_omg_catalogue_nationalarchives_gov_uk":
│  109:   records = data.aws_network_interface.dev_mssql_server_1_database_interface.private_ips
│
│ A data resource "aws_network_interface" "dev_mssql_server_1_database_interface" has not
│ been declared in the root module.`