### PR TITLE
PACT-1046: Dev Workstation Terraform config

### DIFF
--- a/terraform/environments/new/.terraform.lock.hcl
+++ b/terraform/environments/new/.terraform.lock.hcl
@@ -25,6 +25,27 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.3.2"
+  constraints = "2.3.2"
+  hashes = [
+    "h1:Ar/DAbZQ9Nsj0BrqX6camrEE6U+Yq4E87DCNVqxqx8k=",
+    "h1:Vl0aixAYTV/bjathX7VArC5TVNkxBCsi3Vq7R4z1uvc=",
+    "zh:2487e498736ed90f53de8f66fe2b8c05665b9f8ff1506f751c5ee227c7f457d1",
+    "zh:3d8627d142942336cf65eea6eb6403692f47e9072ff3fa11c3f774a3b93130b3",
+    "zh:434b643054aeafb5df28d5529b72acc20c6f5ded24decad73b98657af2b53f4f",
+    "zh:436aa6c2b07d82aa6a9dd746a3e3a627f72787c27c80552ceda6dc52d01f4b6f",
+    "zh:458274c5aabe65ef4dbd61d43ce759287788e35a2da004e796373f88edcaa422",
+    "zh:54bc70fa6fb7da33292ae4d9ceef5398d637c7373e729ed4fce59bd7b8d67372",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:893ba267e18749c1a956b69be569f0d7bc043a49c3a0eb4d0d09a8e8b2ca3136",
+    "zh:95493b7517bce116f75cdd4c63b7c82a9d0d48ec2ef2f5eb836d262ef96d0aa7",
+    "zh:9ae21ab393be52e3e84e5cce0ef20e690d21f6c10ade7d9d9d22b39851bfeddc",
+    "zh:cc3b01ac2472e6d59358d54d5e4945032efbc8008739a6d4946ca1b621a16040",
+    "zh:f23bfe9758f06a1ec10ea3a81c9deedf3a7b42963568997d84a5153f35c5839a",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.4.0"
   constraints = "2.4.0"

--- a/terraform/environments/new/ec2.tf
+++ b/terraform/environments/new/ec2.tf
@@ -1,0 +1,53 @@
+data "aws_ami" "amazon_linux_2_20230719_x86_64" {
+  most_recent = false
+
+  owners = ["137112412989"] # Amazon Web Services
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-kernel-5.10-hvm-2.0.20230719.0-x86_64-gp2"]
+  }
+}
+
+# Dev Workstation for Adam Retter
+resource "aws_instance" "dev_workstation_1" {
+  ami                         = data.aws_ami.amazon_linux_2_20230719_x86_64.id
+  instance_type               = local.instance_type_dev_workstation
+  key_name                    = data.aws_key_pair.omega_admin_key_pair.key_name
+  user_data                   = data.cloudinit_config.dev_workstation_new.rendered
+  user_data_replace_on_change = false
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  monitoring = false
+
+  network_interface {
+    network_interface_id = aws_network_interface.dev_workstation_1_private_interface.id
+    device_index         = 0
+  }
+
+  root_block_device {
+    delete_on_termination = false
+    encrypted             = false
+    volume_type           = "gp3"
+    iops                  = 3000
+    throughput            = 125 # MiB/s
+    volume_size           = 20  # GiB
+
+    tags = {
+      Name        = "root_dev1_new"
+      Type        = "primary_volume"
+      Environment = "dev"
+    }
+  }
+
+  tags = {
+    Name                      = "dev1_new"
+    Type                      = "dev_workstation"
+    Environment               = "dev"
+    scheduler_mon_fri_dev_ec2 = "true"
+  }
+}

--- a/terraform/environments/new/ec2_ebs_volumes.tf
+++ b/terraform/environments/new/ec2_ebs_volumes.tf
@@ -1,0 +1,26 @@
+resource "aws_ebs_volume" "dev_workstation_1_home_volume" {
+  availability_zone = "eu-west-2a"
+  encrypted         = false
+  iops              = 3000
+  type              = "gp3"
+  throughput        = 125
+  size              = 200
+
+  tags = {
+    Name        = "home_dev1_new"
+    Type        = "home_volume"
+    Environment = "dev"
+  }
+
+  /* # Uncomment to enable this argument when the environment is active. 
+  lifecycle {
+        prevent_destroy = true
+  }
+*/
+}
+
+resource "aws_volume_attachment" "dev_workstation_1_home_volume_ebs_att" {
+  device_name = "/dev/xvdb"
+  volume_id   = aws_ebs_volume.dev_workstation_1_home_volume.id
+  instance_id = aws_instance.dev_workstation_1.id
+}

--- a/terraform/environments/new/ec2_network_interfaces.tf
+++ b/terraform/environments/new/ec2_network_interfaces.tf
@@ -76,6 +76,10 @@ resource "aws_network_interface" "dev_workstation_1_private_interface" {
   private_ips        = ["10.129.202.4"]
   ipv6_address_count = 0 # use assign_ipv6_address_on_creation=true from the vpc subnet configuration
 
+  security_groups = [
+    module.dev_workstation_security_group.security_group_id
+  ]
+
   tags = {
     Name        = "eth0_dev1"
     Type        = "primary_network_interface"

--- a/terraform/environments/new/ec2_user_data.tf
+++ b/terraform/environments/new/ec2_user_data.tf
@@ -1,0 +1,38 @@
+data "cloudinit_config" "dev_workstation_new" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/cloud-config"
+    filename     = "omega-mount-volumes.yaml"
+    content      = <<EOF
+#cloud-config
+mounts:
+ - [ "/dev/xvdb", "/home", "xfs", "defaults,nofail", "0", "0" ]
+EOF
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    filename     = "omega-01-format-and-mount-volumes.sh"
+    content      = <<EOF
+#!/usr/bin/env bash
+mkfs -t xfs /dev/xvdb
+cp -rp /home/ec2-user /tmp
+mount /dev/xvdb /home
+mv -f /tmp/ec2-user /home
+HOME_VOLUME_UUID=$(blkid /dev/xvdb | sed -n 's/.*UUID=\"\([^\"]*\)\".*/\1/p')
+bash -c "echo 'UUID=$HOME_VOLUME_UUID     /home       xfs    defaults 0   0' >> /etc/fstab"
+EOF
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    filename     = "yum-upgrade.yaml"
+    content      = <<EOF
+#cloud-config
+package_update: true
+package_upgrade: true
+EOF
+  }
+}

--- a/terraform/environments/new/locals.tf
+++ b/terraform/environments/new/locals.tf
@@ -97,4 +97,6 @@ locals {
   # See `cat /proc/net/sys/ipv4/ip_local_port_range`
   linux_ephemeral_port_start = 32768
   linux_ephemeral_port_end   = 60999
+
+  instance_type_dev_workstation = "t2.micro" # "r6i.2xlarge"
 }

--- a/terraform/environments/new/main.tf
+++ b/terraform/environments/new/main.tf
@@ -19,6 +19,10 @@ terraform {
       source  = "hashicorp/local"
       version = "2.4.0"
     }
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "2.3.2"
+    }
   }
 
   required_version = ">= 1.3.9"
@@ -34,4 +38,14 @@ resource "aws_s3_account_public_access_block" "tna-ct-omega" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+data "aws_key_pair" "omega_admin_key_pair" {
+  key_name           = "omega-admin-key-pair"
+  include_public_key = true
+
+  filter {
+    name   = "tag:Name"
+    values = ["key_pair"]
+  }
 }

--- a/terraform/environments/new/security_groups.tf
+++ b/terraform/environments/new/security_groups.tf
@@ -1,0 +1,99 @@
+module "dev_workstation_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "4.17.2"
+
+  name        = "dev_workstation_security_group_new"
+  description = "Security group for Development Workstation ports open within VPC"
+
+  vpc_id = module.vpc.vpc_id
+
+  computed_ingress_with_cidr_blocks = [
+    {
+      description = "SSH"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = module.vpc.private_subnets_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      description = "return-from-vpc_private_tna_net_subnet_mvpbeta"
+      from_port   = local.linux_ephemeral_port_start
+      to_port     = local.linux_ephemeral_port_end
+      protocol    = "tcp"
+      cidr_blocks = module.vpc.private_subnets_cidr_blocks[8] # NOTE: restricted to vpc_private_tna_net_subnet_mvpbeta
+    },
+    {
+      description = "return-from-vpc_private_subnet_mvpbeta_web"
+      from_port   = local.linux_ephemeral_port_start
+      to_port     = local.linux_ephemeral_port_end
+      protocol    = "tcp"
+      cidr_blocks = module.vpc.private_subnets_cidr_blocks[4] # NOTE: restricted to vpc_private_subnet_mvpbeta_web
+    },
+    {
+      description = "RDP"
+      from_port   = 3389
+      to_port     = 3389
+      protocol    = "tcp"
+      cidr_blocks = module.vpc.private_subnets_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    }
+  ]
+  number_of_computed_ingress_with_cidr_blocks = 4
+
+  computed_ingress_with_ipv6_cidr_blocks = [
+    {
+      description      = "SSH (IPv6)"
+      from_port        = 22
+      to_port          = 22
+      protocol         = "tcp"
+      ipv6_cidr_blocks = module.vpc.private_subnets_ipv6_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general (IPv6)
+    },
+    {
+      description      = "return-from-vpc_private_tna_net_subnet_mvpbeta (IPv6)"
+      from_port        = local.linux_ephemeral_port_start
+      to_port          = local.linux_ephemeral_port_end
+      protocol         = "tcp"
+      ipv6_cidr_blocks = module.vpc.private_subnets_ipv6_cidr_blocks[8] # NOTE: restricted to vpc_private_tna_net_subnet_mvpbeta (IPv6)
+    },
+    {
+      description      = "return-from-vpc_private_subnet_mvpbeta_web (IPv6)"
+      from_port        = local.linux_ephemeral_port_start
+      to_port          = local.linux_ephemeral_port_end
+      protocol         = "tcp"
+      ipv6_cidr_blocks = module.vpc.private_subnets_ipv6_cidr_blocks[4] # NOTE: restricted to vpc_private_subnet_mvpbeta_web (IPv6)
+    },
+    {
+      description      = "RDP (IPv6)"
+      from_port        = 3389
+      to_port          = 3389
+      protocol         = "tcp"
+      ipv6_cidr_blocks = module.vpc.private_subnets_ipv6_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general (IPv6)
+    }
+  ]
+  number_of_computed_ingress_with_ipv6_cidr_blocks = 4
+
+  egress_with_cidr_blocks = [
+    {
+      description = "All"
+      from_port   = -1
+      to_port     = -1
+      protocol    = -1
+      cidr_blocks = "0.0.0.0/0"
+    }
+  ]
+
+  egress_with_ipv6_cidr_blocks = [
+    {
+      description = "All (IPv6)"
+      from_port   = -1
+      to_port     = -1
+      protocol    = -1
+      cidr_blocks = "2001:db8::/64"
+    }
+  ]
+
+  tags = {
+    Name        = "sg_dev_workstation_new"
+    Type        = "security_group"
+    Environment = "dev"
+  }
+}

--- a/terraform/environments/new/vpc.tf
+++ b/terraform/environments/new/vpc.tf
@@ -89,6 +89,86 @@ module "vpc" {
 
   private_inbound_acl_rules = [
     {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number     = 160
+      rule_action     = "allow"
+      from_port       = 22
+      to_port         = 22
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number = 200
+      rule_action = "allow"
+      from_port   = 3389
+      to_port     = 3389
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number     = 260
+      rule_action     = "allow"
+      from_port       = 3389
+      to_port         = 3389
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number = 300
+      rule_action = "allow"
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number     = 360
+      rule_action     = "allow"
+      from_port       = 80
+      to_port         = 80
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number = 400
+      rule_action = "allow"
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number     = 460
+      rule_action     = "allow"
+      from_port       = 443
+      to_port         = 443
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number = 600
+      rule_action = "allow"
+      from_port   = 9443
+      to_port     = 9443
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number     = 660
+      rule_action     = "allow"
+      from_port       = 9443
+      to_port         = 9443
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
       # allow results from outgoing IPv4 internet traffic
       rule_number = 900
       rule_action = "allow"
@@ -110,6 +190,118 @@ module "vpc" {
 
   private_outbound_acl_rules = [
     {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number     = 160
+      rule_action     = "allow"
+      from_port       = 22
+      to_port         = 22
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number = 101
+      rule_action = "allow"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[4] # NOTE: restricted to vpc_private_tna_net_subnet_mvpbeta
+    },
+    {
+      rule_number     = 161
+      rule_action     = "allow"
+      from_port       = 22
+      to_port         = 22
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[4] # NOTE: restricted to vpc_private_tna_net_subnet_mvpbeta
+    },
+    {
+      rule_number = 102
+      rule_action = "allow"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[2] # NOTE: restricted to vpc_private_subnet_mvpbeta_web
+    },
+    {
+      rule_number     = 162
+      rule_action     = "allow"
+      from_port       = 22
+      to_port         = 22
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[2] # NOTE: restricted to vpc_private_subnet_mvpbeta_web
+    },
+    {
+      rule_number = 200
+      rule_action = "allow"
+      from_port   = 3389
+      to_port     = 3389
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number     = 260
+      rule_action     = "allow"
+      from_port       = 3389
+      to_port         = 3389
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
+    },
+    {
+      rule_number = 300
+      rule_action = "allow"
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_block  = "0.0.0.0/0"
+    },
+    {
+      rule_number     = 360
+      rule_action     = "allow"
+      from_port       = 80
+      to_port         = 80
+      protocol        = "tcp"
+      ipv6_cidr_block = "::/0"
+    },
+    {
+      rule_number = 400
+      rule_action = "allow"
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_block  = "0.0.0.0/0"
+    },
+    {
+      rule_number     = 460
+      rule_action     = "allow"
+      from_port       = 443
+      to_port         = 443
+      protocol        = "tcp"
+      ipv6_cidr_block = "::/0"
+    },
+    {
+      rule_number = 500
+      rule_action = "allow"
+      from_port   = 9443
+      to_port     = 9443
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[2] # NOTE: restricted to vpc_private_subnet_mvpbeta_web
+    },
+    {
+      rule_number     = 560
+      rule_action     = "allow"
+      from_port       = 9443
+      to_port         = 9443
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[2] # NOTE: restricted to vpc_private_subnet_mvpbeta_web
+    },
+    {
       # allow IPv4 return traffic from vpc_private_subnet_dev_general
       rule_number = 1200
       rule_action = "allow"
@@ -126,7 +318,25 @@ module "vpc" {
       to_port         = local.linux_ephemeral_port_end
       protocol        = "tcp"
       ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[0] # NOTE: restricted to vpc_private_subnet_dev_general
-    }
+    },
+    {
+      # allow IPv4 return traffic from vpc_private_tna_net_subnet_mvpbeta
+      rule_number = 1400
+      rule_action = "allow"
+      from_port   = local.linux_ephemeral_port_start
+      to_port     = local.linux_ephemeral_port_end
+      protocol    = "tcp"
+      cidr_block  = module.vpc.private_subnets_cidr_blocks[4] # NOTE: restricted to vpc_private_tna_net_subnet_mvpbeta
+    },
+    {
+      # allow IPv6 return traffic from vpc_private_subnet_mvpbeta_web
+      rule_number     = 1460
+      rule_action     = "allow"
+      from_port       = local.linux_ephemeral_port_start
+      to_port         = local.linux_ephemeral_port_end
+      protocol        = "tcp"
+      ipv6_cidr_block = module.vpc.private_subnets_ipv6_cidr_blocks[4] # NOTE: restricted to vpc_private_subnet_mvpbeta_web
+    },
   ]
 
   vpc_tags = {


### PR DESCRIPTION
This PR defines a single Dev Workstation to be used as a template for the remaining workstations.
This will create an EC2 instance with a 20Gb root ebs volume and a secondary 200Gb /home volume, also a secondary network interface in the database subnet and also the workstation security groups.
The cloudinit_config user-data has been modified in order to move the ec2-user home directory including the required `.ssh` subdirectory and `authorized_keys` file from the root volume onto the secondary volume used for the /home filesystem
Additional NACL's have been added to allow SSH traffic both in and outbound
Updated the cloudinit scripts to mount the secondary disk and update the /etc/fstab