### PR TITLE
PACT 1047: MSSQL Server Terraform config

### DIFF
--- a/terraform/environments/new/ec2_ebs_volumes.tf
+++ b/terraform/environments/new/ec2_ebs_volumes.tf
@@ -51,3 +51,82 @@ resource "aws_volume_attachment" "dev_workstation_2_home_volume_ebs_att" {
   volume_id   = aws_ebs_volume.dev_workstation_2_home_volume.id
   instance_id = aws_instance.dev_workstation_2.id
 }
+
+resource "aws_ebs_volume" "dev_mssql_server_1_data_volume" {
+  availability_zone = "eu-west-2a"
+  encrypted         = false
+  iops              = 3000
+  type              = "gp3"
+  throughput        = 125
+  size              = 150
+
+/* # Uncomment to enable this argument when the environment is active. 
+  lifecycle {
+    prevent_destroy = true
+  }
+*/
+  tags = {
+    Name        = "data_mssql1_new"
+    Type        = "mssql_data_volume"
+    Environment = "dev"
+  }
+}
+
+resource "aws_ebs_volume" "dev_mssql_server_1_log_volume" {
+  availability_zone = "eu-west-2a"
+  encrypted         = false
+  iops              = 3000
+  type              = "gp3"
+  throughput        = 125
+  size              = 75
+
+/* # Uncomment to enable this argument when the environment is active. 
+  lifecycle {
+    prevent_destroy = true
+  }
+*/
+  tags = {
+    Name        = "log_mssql1_new"
+    Type        = "mssql_log_volume"
+    Environment = "dev"
+  }
+}
+
+resource "aws_ebs_volume" "dev_mssql_server_1_backup_volume" {
+  availability_zone = "eu-west-2a"
+  encrypted         = false
+  iops              = 3000
+  type              = "gp3"
+  throughput        = 125
+  size              = 150
+
+/* # Uncomment to enable this argument when the environment is active. 
+  lifecycle {
+    prevent_destroy = true
+  }
+*/
+
+  tags = {
+    Name        = "backup_mssql1_new"
+    Type        = "mssql_backup_volume"
+    Environment = "dev"
+  }
+}
+
+resource "aws_volume_attachment" "dev_mssql_server_1_data_volume_ebs_att" {
+  device_name = "/dev/xvdb"
+  volume_id   = aws_ebs_volume.dev_mssql_server_1_data_volume.id
+  instance_id = aws_instance.dev_mssql_server_1.id
+}
+
+resource "aws_volume_attachment" "dev_mssql_server_1_log_volume_ebs_att" {
+  device_name = "/dev/xvdc"
+  volume_id   = aws_ebs_volume.dev_mssql_server_1_log_volume.id
+  instance_id = aws_instance.dev_mssql_server_1.id
+}
+
+resource "aws_volume_attachment" "dev_mssql_server_1_backup_volume_ebs_att" {
+  device_name = "/dev/xvdd"
+  volume_id   = aws_ebs_volume.dev_mssql_server_1_backup_volume.id
+  instance_id = aws_instance.dev_mssql_server_1.id
+}

--- a/terraform/environments/new/ec2_user_data.tf
+++ b/terraform/environments/new/ec2_user_data.tf
@@ -36,3 +36,57 @@ package_upgrade: true
 EOF
   }
 }
+
+data "cloudinit_config" "mssql_server_new" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/cloud-config"
+    filename     = "omega-mount-volumes.yaml"
+    content      = <<EOF
+#cloud-config
+mounts:
+ - [ xvdb, /mssql/data, "xfs", "defaults,nofail", "0", "0" ]
+ - [ xvdc, /mssql/log, "xfs", "defaults,nofail", "0", "0" ]
+ - [ xvdd, /mssql/backup, "xfs", "defaults,nofail", "0", "0" ]
+EOF
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    filename     = "omega-yum-upgrade.yaml"
+    content      = <<EOF
+#cloud-config
+package_update: true
+package_upgrade: true
+EOF
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    filename     = "omega-01-format-and-mount-volumes.sh"
+    content      = <<EOF
+#!/usr/bin/env bash
+mkfs -t xfs /dev/xvdb
+mkfs -t xfs /dev/xvdc
+mkfs -t xfs /dev/xvdd
+
+mount /dev/xvdb
+mount /dev/xvdc
+mount /dev/xvdd
+EOF
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    filename     = "reboot.yaml"
+    content      = <<EOF
+#cloud-config
+power_state:
+    delay: now
+    mode: reboot
+    message: Rebooting machine after Omega cloud-init Initialisation Completed
+EOF
+  }
+}

--- a/terraform/environments/new/locals.tf
+++ b/terraform/environments/new/locals.tf
@@ -99,4 +99,6 @@ locals {
   linux_ephemeral_port_end   = 60999
 
   instance_type_dev_workstation = "t2.micro" # "r6i.2xlarge"
+
+  instance_type_dev_mssql_server = "t2.micro" # "r5.xlarge"
 }


### PR DESCRIPTION
This PR defines a single Dev MSSQL Server EC2 instance.
This will create an EC2 instance with:
* a 60Gb root ebs volume
* a 150Gb /mssql/data volume
* a 75Gb /mssql/log volume
* a 150Gb /mssql/backup volume
