### PR TITLE
PACT-1099 Disable auto stop start ec2 scheduler

### DIFF
--- a/terraform/environments/existing/main.tf
+++ b/terraform/environments/existing/main.tf
@@ -1469,7 +1469,7 @@ resource "aws_instance" "dev_workstation_4" {
     Name                      = "dev4"
     Type                      = "dev_workstation"
     Environment               = "dev"
-    scheduler_mon_fri_dev_ec2 = "true"
+    #scheduler_mon_fri_dev_ec2 = "true"
   }
 }
 


### PR DESCRIPTION
This PR will remove the tag `scheduler_mon_fri_dev_ec2` used by the automated stop start lambda scheduler from the dev4 workstation in the `terraform/environments/existing` environment code which is no longer in use.